### PR TITLE
Removed the duplicated "Forgot Password?" (contained in django-allauth).

### DIFF
--- a/geonode/templates/account/login.html
+++ b/geonode/templates/account/login.html
@@ -40,9 +40,6 @@
       {% if redirect_field_value %}
         <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
       {% endif %}
-      <div class="form-group">
-          <p><a href="{% url 'account_reset_password' %}">{% trans "Forgot Password?" %}</a></p>
-      </div>
       <button class="btn btn-primary" type="submit">{% trans "Sign In" %}</button>
     </form>
   </div>


### PR DESCRIPTION
With the new django-allauth version, the *Forgot your password?* link is already included in the form, therefore I deleted the additional link from Geonode's template.